### PR TITLE
#16 Code Coverage For clone.js

### DIFF
--- a/utils/clone.test.js
+++ b/utils/clone.test.js
@@ -1,0 +1,24 @@
+const clone = require('./clone')
+
+const fs = require('fs');
+
+describe('Tests Code within clone.js', () => {
+  it('Should test clone.safeClone(filePath)', () => {
+    const mockedModuleData = {
+      "key1": "value1",
+      "key2": ["str1", "str2"],
+      "key3": {
+        "subKey1": "subValue1"
+      }
+    }
+    // will make fs.existsSync(filePath) return true 1 time regardless of the filepath exists or not
+    // noinspection JSCheckFunctionSignatures <reason: 3rd arg is optional for jest.spyOn. We do not need it, false postitve>
+    jest.spyOn(fs, "existsSync").mockImplementationOnce(() => jest.fn())
+    //when require(mockedModule) is invoked, it will virtually contain the object below
+    jest.mock("/fake/data.json", () => mockedModuleData, {virtual: true})
+
+
+    expect(clone.safeClone("/fake/data.json")).toStrictEqual(mockedModuleData)
+    expect(clone.safeClone("/fake/data.json")).toStrictEqual([])
+  })
+})

--- a/utils/write.test.js
+++ b/utils/write.test.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 
 describe('Tests Code within write.js', () => {
   it('Should test write.dataToFile(file, data) with correct arguments', () => {
+    // noinspection JSCheckFunctionSignatures <reason: 3rd arg is optional for jest.spyOn. We do not need it, false postitve>
     jest.spyOn(fs, 'writeFileSync').mockImplementationOnce(() => jest.fn())
     write.dataToFile('path/to/output/file.json', {"name": "Jake", "dog": {"name": "Bailey", "size": "small"}})
 


### PR DESCRIPTION
- 100% code coverage for clone.js
-     // noinspection JSCheckFunctionSignatures added to all usages of jest.spyOn. Reason being the 3rd argument to spyOn is optional, Intellij is interpreting this method wrong. This inspection is turned off inline as we still want the rule globally.